### PR TITLE
Use foreign configuration instead of touching unused files

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-touch AUTHORS ChangeLog NEWS README
 aclocal
 autoconf
 automake --add-missing -c

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ PKG_CONFIG=$_save_PKG_CONFIG[]dnl
 
 # Checks for libraries.
 PKG_CHECK_MODULES_STATIC(FreeType, [freetype2])
-PKG_CHECK_MODULES_STATIC(ImageMagick, [Magick++ >= 6.0.0])
+PKG_CHECK_MODULES_STATIC(ImageMagick, [Magick++ >= 6.0.0 Magick++ < 7.0.0])
 
 # Checks for header files.
 AC_CHECK_HEADERS([unistd.h])

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ PKG_CONFIG=$_save_PKG_CONFIG[]dnl
 
 # Checks for libraries.
 PKG_CHECK_MODULES_STATIC(FreeType, [freetype2])
-PKG_CHECK_MODULES_STATIC(ImageMagick, [Magick++ >= 6.0.0 Magick++ < 7.0.0])
+PKG_CHECK_MODULES_STATIC(ImageMagick, [Magick++ >= 6.0.0])
 
 # Checks for header files.
 AC_CHECK_HEADERS([unistd.h])

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([tex3ds], [1.0.1], [https://github.com/devkitPro/tex3ds/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([source/tex3ds.cpp])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # Checks for programs.
 AC_PROG_CXX

--- a/source/mkbcfnt.cpp
+++ b/source/mkbcfnt.cpp
@@ -120,12 +120,6 @@ int main(int argc, char *argv[])
     }
   }
 
-  if(output_path.empty())
-  {
-    std::fprintf(stderr, "No output file provided\n");
-    return EXIT_FAILURE;
-  }
-
   if(optind >= argc)
   {
     std::fprintf(stderr, "No input file provided\n");
@@ -139,6 +133,12 @@ int main(int argc, char *argv[])
   }
 
   std::string input_path = argv[optind];
+
+  if(output_path.empty())
+  {
+    output_path = input_path.substr(0, input_path.find_last_of('.'))+".bcfnt";
+    std::fprintf(stderr, "No output file provided. Automaticly choosing one.\n");
+  }
 
   FT_Library library;
   FT_Error error = FT_Init_FreeType(&library);

--- a/source/mkbcfnt.cpp
+++ b/source/mkbcfnt.cpp
@@ -120,6 +120,12 @@ int main(int argc, char *argv[])
     }
   }
 
+  if(output_path.empty())
+  {
+    std::fprintf(stderr, "No output file provided\n");
+    return EXIT_FAILURE;
+  }
+
   if(optind >= argc)
   {
     std::fprintf(stderr, "No input file provided\n");
@@ -133,12 +139,6 @@ int main(int argc, char *argv[])
   }
 
   std::string input_path = argv[optind];
-
-  if(output_path.empty())
-  {
-    output_path = input_path.substr(0, input_path.find_last_of('.'))+".bcfnt";
-    std::fprintf(stderr, "No output file provided. Automaticly choosing one.\n");
-  }
 
   FT_Library library;
   FT_Error error = FT_Init_FreeType(&library);


### PR DESCRIPTION
Makes having an output path optional and fixes libmagick++ dependency checking.
Also, is there any reason for doing `touch AUTHORS ChangeLog NEWS README` over just doing `AM_INIT_AUTOMAKE([foreign])`

This pr is for feature/mkbcfnt, not master. If you would like me to make any changes, or make a separate pr for some of the changes to be commited to master, just let me know. I assume that feature/mkbcfnt will be merged with master, so it shouldn't be an issue to commit all these to that branch.