### PR TITLE
Fix adding compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,10 +12,10 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX
 
 AC_LANG_PUSH([C++])
-AX_CHECK_COMPILE_FLAG([-Wall],      [CPPFLAGS+=" -Wall"])
-AX_CHECK_COMPILE_FLAG([-pthread],   [CPPFLAGS+=" -pthread" LDFLAGS+=" -pthread"])
-AX_CHECK_COMPILE_FLAG([-flto],      [CPPFLAGS+=" -flto" LDFLAGS+=" -flto"])
-AX_CHECK_COMPILE_FLAG([-pipe],      [CPPFLAGS+=" -pipe"])
+AX_CHECK_COMPILE_FLAG([-Wall],      [CPPFLAGS="$CPPFLAGS -Wall"])
+AX_CHECK_COMPILE_FLAG([-pthread],   [CPPFLAGS="$CPPFLAGS -pthread" LDFLAGS="$LDFLAGS -pthread"])
+AX_CHECK_COMPILE_FLAG([-flto],      [CPPFLAGS="$CPPFLAGS -flto" LDFLAGS="$LDFLAGS -flto"])
+AX_CHECK_COMPILE_FLAG([-pipe],      [CPPFLAGS="$CPPFLAGS -pipe"])
 AX_CXX_COMPILE_STDCXX_11(noext, mandatory)
 AC_LANG_POP()
 


### PR DESCRIPTION
When building tex3ds, I get the following warning.

checking whether C++ compiler accepts -Wall... yes
./configure: 3568: ./configure: CPPFLAGS+= -Wall: not found

checking whether C++ compiler accepts -pthread... yes
./configure: 3603: ./configure: CPPFLAGS+= -pthread: not found

checking whether C++ compiler accepts -flto... yes
./configure: 3638: ./configure: CPPFLAGS+= -flto: not found

checking whether C++ compiler accepts -pipe... yes
./configure: 3673: ./configure: CPPFLAGS+= -pipe: not found

checking whether g++ supports C++11 features by default... yes

With the latest commit (allow static linking), these warnings cause the application to fail to compile. I just changed the declarations so it should work on most systems.