### PR TITLE
lzss.cpp: use memcmp to optimize match-checking

### DIFF
--- a/source/lzss.cpp
+++ b/source/lzss.cpp
@@ -89,7 +89,7 @@ const uint8_t *find_best_match (const uint8_t *start,
 	while ((p = rfind (start, p, *buffer)))
 	{
 		// confirm that this match is as good as the best match so far
-		if(memcmp(p, buffer, best_len))
+		if (std::memcmp (p, buffer, best_len) != 0)
 			continue;
 
 		// find length of match

--- a/source/lzss.cpp
+++ b/source/lzss.cpp
@@ -83,13 +83,18 @@ const uint8_t *find_best_match (const uint8_t *start,
 	const uint8_t *best_start = buffer;
 	size_t best_len           = 0;
 
+	const uint8_t *p = buffer;
+
 	// find nearest matching start byte
-	const uint8_t *p = rfind (start, buffer, *buffer);
-	while (p)
+	while ((p = rfind (start, p, *buffer)))
 	{
+		// confirm that this match is as good as the best match so far
+		if(memcmp(p, buffer, best_len))
+			continue;
+
 		// find length of match
-		size_t test_len = 1;
-		for (size_t i = 1; i < len; ++i)
+		size_t test_len = best_len;
+		for (size_t i = best_len; i < len; ++i)
 		{
 			if (p[i] == buffer[i])
 				++test_len;
@@ -107,9 +112,6 @@ const uint8_t *find_best_match (const uint8_t *start,
 		// if we maximized the match, stop here
 		if (best_len == len)
 			break;
-
-		// find next nearest matching byte and try again
-		p = rfind (start, p, *buffer);
 	}
 
 	if (best_len)


### PR DESCRIPTION
I recently started work on a stripped-down library fork of this tool for use in a conversion toolkit. While doing some profiling I found that the hottest code was in the LZ11 compression procedure. On my x86 machine at least, switching to `memcmp` rather than a manual loop for the comparison up to `best_len` sped up conversion overall by a factor of 4. Maybe this change will be useful to you upstream as well.