### PR TITLE
Fix TGLP size output

### DIFF
--- a/source/bcfnt.cpp
+++ b/source/bcfnt.cpp
@@ -606,6 +606,8 @@ bool BCFNT::serialize (const std::string &path)
 	const std::uint32_t sheetOffset = (fileSize + MASK) & ~MASK;
 	fileSize                        = sheetOffset + sheetImages.size () * SHEET_SIZE;
 
+	const std::uint32_t totalTglpSize = fileSize - tglpOffset;
+
 	// CWDH headers + data
 	const std::uint32_t cwdhOffset = fileSize;
 	fileSize += 0x10;                          // CWDH header
@@ -676,7 +678,7 @@ bool BCFNT::serialize (const std::string &path)
 	// TGLP header
 	assert (std::distance (std::begin (output), it) == tglpOffset);
 	it << "TGLP"                                    // magic
-	   << static_cast<std::uint32_t> (0x20)         // section size
+	   << static_cast<std::uint32_t> (totalTglpSize)         // section size
 	   << static_cast<std::uint8_t> (cellWidth)     // cell width
 	   << static_cast<std::uint8_t> (cellHeight)    // cell height
 	   << static_cast<std::uint8_t> (ascent)        // cell baseline

--- a/source/bcfnt.cpp
+++ b/source/bcfnt.cpp
@@ -717,7 +717,7 @@ bool BCFNT::serialize (const std::string &path)
 	it << "CWDH"                                                              // magic
 	   << static_cast<std::uint32_t> (0x10 + ((3 * glyphs.size () + 3) & ~3)) // section size
 	   << static_cast<std::uint16_t> (0)                                      // start index
-	   << static_cast<std::uint16_t> (glyphs.size ())                         // end index
+	   << static_cast<std::uint16_t> (glyphs.size () - 1)                     // end index
 	   << static_cast<std::uint32_t> (0);                                     // next CWDH offset
 
 	for (const auto &info : glyphs)


### PR DESCRIPTION
Turns out official software actually uses this field. Who knew?
As far as I'm aware they use this for a sanity check, which causes current mkbcfnt output to crash APT in the case of modifying system font. Probably applies to some games too.