### PR TITLE
Fix some TGLP values to match actual use

### DIFF
--- a/source/bcfnt.cpp
+++ b/source/bcfnt.cpp
@@ -341,13 +341,6 @@ void BCFNT::addFont (std::shared_ptr<freetype::Face> face_,
 	int descent = std::numeric_limits<int>::max ();
 
 	lineFeed = std::max (lineFeed, static_cast<std::uint8_t> (face->size->metrics.height >> 6));
-	height =
-	    std::max (height, static_cast<std::uint8_t> ((face->bbox.yMax - face->bbox.yMin) >> 6));
-	width = std::max (width, static_cast<std::uint8_t> ((face->bbox.xMax - face->bbox.xMin) >> 6));
-	maxWidth =
-	    std::max (maxWidth, static_cast<std::uint8_t> (face->size->metrics.max_advance >> 6));
-	ascent  = std::max (ascent, static_cast<std::uint8_t> (face->size->metrics.ascender >> 6));
-	descent = std::min (descent, static_cast<int> (face->size->metrics.descender) >> 6);
 
 	std::vector<std::shared_future<void>> futures;
 	std::mutex mutex;
@@ -385,6 +378,8 @@ void BCFNT::addFont (std::shared_ptr<freetype::Face> face_,
 				descent =
 				    std::min<int> (descent, face->glyph->bitmap_top - face->glyph->bitmap.rows);
 				maxWidth = std::max<std::uint8_t> (maxWidth, face->glyph->bitmap.width);
+				height = std::max<std::uint8_t> (height, face->glyph->metrics.height >> 6);
+				width = std::max<std::uint8_t> (width, face->glyph->metrics.width >> 6);
 
 				glyphs.emplace (code, glyph);
 			};

--- a/source/bcfnt.cpp
+++ b/source/bcfnt.cpp
@@ -661,9 +661,9 @@ bool BCFNT::serialize (const std::string &path)
 	   << static_cast<std::uint8_t> (0x1)                     // font type
 	   << static_cast<std::uint8_t> (lineFeed)                // line feed
 	   << static_cast<std::uint16_t> (altIndex)               // alternate char index
-	   << static_cast<std::uint8_t> (defaultWidth.left)       // default width (left)
-	   << static_cast<std::uint8_t> (defaultWidth.glyphWidth) // default width (glyph width)
-	   << static_cast<std::uint8_t> (defaultWidth.charWidth)  // default width (char width)
+	   << static_cast<std::uint8_t> (0)                       // default width (left)
+	   << static_cast<std::uint8_t> (cellWidth)               // default width (glyph width)
+	   << static_cast<std::uint8_t> (cellWidth)               // default width (char width)
 	   << static_cast<std::uint8_t> (0x1)                     // encoding
 	   << static_cast<std::uint32_t> (tglpOffset + 8)         // TGLP offset
 	   << static_cast<std::uint32_t> (cwdhOffset + 8)         // CWDH offset


### PR DESCRIPTION
I'm not entirely certain *what* "default width" is *supposed* to be, but this is much closer to the examples that we have (i.e. all four system fonts).
Also, some fonts have highly variable glyph sizes, and filters can cause some strange issues because of that. Using only the glyphs that are included for sizing information mostly fixes that problem.